### PR TITLE
fix[#30]: use the `sampleRate` of the created audio track

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### vNext
 
+- Fixed an issue where speech recognition was using an incorrect sample rate.
+
 ### v4.0.0
 
 - **BREAKING:** This packages now exports ES Module only.

--- a/src/Playthrough.ts
+++ b/src/Playthrough.ts
@@ -440,7 +440,10 @@ class Playthrough extends EventEmitter<PlaythroughEvents> {
 
   public async startSpeechRecognition(event?: SpeechRecognitionStartEvent) {
     if (!this.microphone) {
-      this.microphone = new MicrophoneRecorder();
+      // if the user supplied a `sampleRate`, try and create a recorder that matches it
+      this.microphone = new MicrophoneRecorder({
+        sampleRate: event?.sampleRate,
+      });
       this.microphone.addListener("data", (data) => {
         this.addOutgoingEvent("speech-recognition-chunk", data);
       });
@@ -450,6 +453,9 @@ class Playthrough extends EventEmitter<PlaythroughEvents> {
 
     this.addOutgoingEvent("speech-recognition-start", {
       ...event,
+      // the recorder is NOT GUARANTEED to have the `sampleRate` the user specified.
+      // override the event with the actual `sampleRate`.
+      sampleRate: this.microphone.sampleRate,
     });
   }
 


### PR DESCRIPTION
Closes #30 

The browser doesn't guarantee that it returns a track from `getUserMedia` matching the constraints that you've passed to it - it's a fuzzy kind of match. So it may give you back a track with an entirely different `sampleRate` to what you asked for.

If that's the case, now we actually use the correct sample rate (from the track) instead of what the user supplied.